### PR TITLE
 Button styling  active stick for touchscreen

### DIFF
--- a/dist/index.css
+++ b/dist/index.css
@@ -45,7 +45,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -60,6 +61,7 @@
     outline: none;
     box-shadow: none; }
   ._Status__dialpadButton__38DZj:active {
+    transition: none;
     background-color: #b2c7f1; }
 
 ._Status__dialpadButtonLetters__N-jqm {
@@ -77,7 +79,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -101,7 +104,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -117,6 +121,7 @@
     outline: none;
     box-shadow: none; }
   ._Status__endCallButton__3z8u3:active {
+    transition: none;
     background-color: #fca09c; }
 
 ._Status__startCallButton__3UW76 {
@@ -126,7 +131,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -137,11 +143,14 @@
   font-size: 1em;
   background-color: lightgray;
   margin: 25px;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #15c73b; }
   ._Status__startCallButton__3UW76:focus {
     outline: none;
     box-shadow: none; }
   ._Status__startCallButton__3UW76:active {
+    transition: none;
     background-color: #71c082; }
 
 ._Status__actionsContainer__2kDeL {
@@ -189,7 +198,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -226,7 +236,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -306,7 +317,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -321,6 +333,7 @@
     outline: none;
     box-shadow: none; }
   ._Phone__dialpadButton__2Mev0:active {
+    transition: none;
     background-color: #b2c7f1; }
 
 ._Phone__dialpadButtonLetters__30C7x {
@@ -338,7 +351,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -362,7 +376,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -378,6 +393,7 @@
     outline: none;
     box-shadow: none; }
   ._Phone__endCallButton__EoCL2:active {
+    transition: none;
     background-color: #fca09c; }
 
 ._Phone__startCallButton__PaJuy {
@@ -387,7 +403,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -398,11 +415,14 @@
   font-size: 1em;
   background-color: lightgray;
   margin: 25px;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #15c73b; }
   ._Phone__startCallButton__PaJuy:focus {
     outline: none;
     box-shadow: none; }
   ._Phone__startCallButton__PaJuy:active {
+    transition: none;
     background-color: #71c082; }
 
 ._Phone__actionsContainer__25gV2 {
@@ -450,7 +470,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -479,7 +500,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -502,7 +524,8 @@
   width: 60px;
   height: 60px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   background-color: #96bdf7;
   color: #333132;
   cursor: pointer;
@@ -519,6 +542,7 @@
     outline: none;
     box-shadow: none; }
   ._Dialstring__dialButtonStrict__tfL15:active {
+    transition: none;
     background-color: #8beb9f; }
 
 ._Dialstring__dialInput__32AFz {

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -13,7 +13,7 @@ const disabledFeatures = urlParams.get('features')
 const outsideComponentDial = urlParams.get('dial')
 const mode = urlParams.get('mode')
 
-//example url 
+//example url
 //http://localhost:3000/phone/react-sip-phone?name=testname&websocket=wss://test-websocket-01-us-east-5.test.com:5065
 //&sipuri=user_test@test.domain.com&password=tEsTpAsSwOrD&features=callbuttonsettings&buttons=holdtransfermute
 
@@ -21,15 +21,25 @@ const App = () => {
   const [dialstring, setDialstring] = useState('')
   return (
     <React.Fragment>
-      {outsideComponentDial ? <div>
-        <input placeholder="Enter a number to dial"
-          onChange={(e) => setDialstring(e.target.value)} />
-        <button onClick={() => {
-          if (phoneStore.getState().sipAccounts.sipAccount && dialstring) {
-            phoneStore.getState().sipAccounts.sipAccount.makeCall(dialstring)
-          }
-        }}>Dial</button>
-      </div> : null}
+      {outsideComponentDial ? (
+        <div>
+          <input
+            placeholder='Enter a number to dial'
+            onChange={(e) => setDialstring(e.target.value)}
+          />
+          <button
+            onClick={() => {
+              if (phoneStore.getState().sipAccounts.sipAccount && dialstring) {
+                phoneStore
+                  .getState()
+                  .sipAccounts.sipAccount.makeCall(dialstring)
+              }
+            }}
+          >
+            Dial
+          </button>
+        </div>
+      ) : null}
       <ReactSipPhone
         name={name || ''}
         sipCredentials={{
@@ -38,21 +48,21 @@ const App = () => {
         }}
         sipConfig={{
           websocket: websocket || '',
-          defaultCountryCode: '1',
+          defaultCountryCode: '1'
         }}
         phoneConfig={{
           disabledButtons: disabledButtons || '', // Will remove button(s) from Phone component. E.g. hold transfer dialpadopen mute '
           disabledFeatures: disabledFeatures || '', // Will remove feature(s) from application. E.g. settings remoteid
-          defaultDial: '',          // (strict-mode only) the default destination. E.g. 1234567890
-          sessionsLimit: 3,         // limits amount of sessions user can have active   
-          attendedTransferLimit: 2  // limits amount of attendedTransfer sessions user can have active     
+          defaultDial: '6143543760', // (strict-mode only) the default destination. E.g. 1234567890
+          sessionsLimit: 3, // limits amount of sessions user can have active
+          attendedTransferLimit: 2 // limits amount of attendedTransfer sessions user can have active
         }}
         appConfig={{
-          mode: mode || '', // 'strict' will activate a simple and limited user experience. set to sessionLimit 1 if using 'strict'          
+          mode: mode || '', // 'strict' will activate a simple and limited user experience. set to sessionLimit 1 if using 'strict'
           started: false, // (strict-mode only) keeps track of call button visability during strict-mode
           appSize: 'large' // assign 'large' for larger font in status-name and session-status (not session remote-id/display name)
         }}
-        width={450} // when using strict mode, set width={450} for dialpad buttons and phone action-buttons to line up 
+        width={450} // when using strict mode, set width={450} for dialpad buttons and phone action-buttons to line up
       />
     </React.Fragment>
   )

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -13,7 +13,7 @@ const disabledFeatures = urlParams.get('features')
 const outsideComponentDial = urlParams.get('dial')
 const mode = urlParams.get('mode')
 
-//example url
+//example url 
 //http://localhost:3000/phone/react-sip-phone?name=testname&websocket=wss://test-websocket-01-us-east-5.test.com:5065
 //&sipuri=user_test@test.domain.com&password=tEsTpAsSwOrD&features=callbuttonsettings&buttons=holdtransfermute
 
@@ -21,25 +21,15 @@ const App = () => {
   const [dialstring, setDialstring] = useState('')
   return (
     <React.Fragment>
-      {outsideComponentDial ? (
-        <div>
-          <input
-            placeholder='Enter a number to dial'
-            onChange={(e) => setDialstring(e.target.value)}
-          />
-          <button
-            onClick={() => {
-              if (phoneStore.getState().sipAccounts.sipAccount && dialstring) {
-                phoneStore
-                  .getState()
-                  .sipAccounts.sipAccount.makeCall(dialstring)
-              }
-            }}
-          >
-            Dial
-          </button>
-        </div>
-      ) : null}
+      {outsideComponentDial ? <div>
+        <input placeholder="Enter a number to dial"
+          onChange={(e) => setDialstring(e.target.value)} />
+        <button onClick={() => {
+          if (phoneStore.getState().sipAccounts.sipAccount && dialstring) {
+            phoneStore.getState().sipAccounts.sipAccount.makeCall(dialstring)
+          }
+        }}>Dial</button>
+      </div> : null}
       <ReactSipPhone
         name={name || ''}
         sipCredentials={{
@@ -48,21 +38,21 @@ const App = () => {
         }}
         sipConfig={{
           websocket: websocket || '',
-          defaultCountryCode: '1'
+          defaultCountryCode: '1',
         }}
         phoneConfig={{
           disabledButtons: disabledButtons || '', // Will remove button(s) from Phone component. E.g. hold transfer dialpadopen mute '
           disabledFeatures: disabledFeatures || '', // Will remove feature(s) from application. E.g. settings remoteid
-          defaultDial: '6143543760', // (strict-mode only) the default destination. E.g. 1234567890
-          sessionsLimit: 3, // limits amount of sessions user can have active
-          attendedTransferLimit: 2 // limits amount of attendedTransfer sessions user can have active
+          defaultDial: '',          // (strict-mode only) the default destination. E.g. 1234567890
+          sessionsLimit: 3,         // limits amount of sessions user can have active   
+          attendedTransferLimit: 2  // limits amount of attendedTransfer sessions user can have active     
         }}
         appConfig={{
-          mode: mode || '', // 'strict' will activate a simple and limited user experience. set to sessionLimit 1 if using 'strict'
+          mode: mode || '', // 'strict' will activate a simple and limited user experience. set to sessionLimit 1 if using 'strict'          
           started: false, // (strict-mode only) keeps track of call button visability during strict-mode
           appSize: 'large' // assign 'large' for larger font in status-name and session-status (not session remote-id/display name)
         }}
-        width={450} // when using strict mode, set width={450} for dialpad buttons and phone action-buttons to line up
+        width={450} // when using strict mode, set width={450} for dialpad buttons and phone action-buttons to line up 
       />
     </React.Fragment>
   )

--- a/src/components/Dialstring.scss
+++ b/src/components/Dialstring.scss
@@ -7,14 +7,15 @@
   background: none;
 }
 
-.dialButtonStrict{
+.dialButtonStrict {
   border: 0;
   padding: 0;
   background: none;
   width: 60px;
   height: 60px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   &:focus {
     outline: none;
     box-shadow: none;
@@ -31,7 +32,8 @@
   width: 100%;
   background: none;
   background-color: #15c73b;
-  &:active{
+  &:active {
+    transition: none;
     background-color: #8beb9f;
   }
 }
@@ -46,7 +48,6 @@
   justify-content: space-between;
   width: 100%;
   padding: 0 0 0 0px;
-
 }
 
 .dialstringContainer {

--- a/src/components/phone/Phone.scss
+++ b/src/components/phone/Phone.scss
@@ -46,7 +46,7 @@
   }
 }
 
-.statusLarge{
+.statusLarge {
   padding: 2px;
   font-size: 40px;
 }
@@ -55,7 +55,8 @@
   @include common-button;
   @include phone-buttons;
   font-size: 2em;
-  &:active{
+  &:active {
+    transition: none;
     background-color: #b2c7f1;
   }
 }
@@ -82,7 +83,8 @@
   @include common-button;
   @include action-buttons;
   background-color: #ff6961;
-  &:active{
+  &:active {
+    transition: none;
     background-color: #fca09c;
   }
 }
@@ -90,8 +92,12 @@
 .startCallButton {
   @include common-button;
   @include action-buttons;
+  transition: all 0.2s;
+  transition-delay: 300ms;
+
   background-color: #15c73b;
-  &:active{
+  &:active {
+    transition: none;
     background-color: #71c082;
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,6 @@
 @import './variables';
 
-//Detecting devices with hover enabled 
+//Detecting devices with hover enabled
 // @media (hover: hover) {
 //   button:hover {
 //     &:hover {
@@ -21,7 +21,8 @@
   width: 100px;
   height: 100px;
   border-radius: 10px;
-  transition: opacity 0.5s ease;
+  transition: all 0.2s;
+  transition-delay: 300ms;
   &:focus {
     outline: none;
     box-shadow: none;
@@ -51,5 +52,5 @@
   justify-content: flex-start;
   align-items: center;
   height: 100%;
-  font-family: Arial, Helvetica, sans-serif
+  font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
The CSS :active psuedo style is displayed between the time when a user touches down (when finger contacts screen) on a element to the time when the touch up (when finger leaves the screen) occures. With a typical touch-screen tap interaction, the time of which the :active psuedo style is displayed can be very small resulting in the :active state not showing or being missed by the user entirely. This can cause issues with users not undertanding if their button presses have actually reigstered or not.

Having the the :active styling stick around for a few hundred more milliseconds after touch up would would improve user understanding when they have interacted with a button.