### PR TITLE
[fix](phone) fix to accept & decline callsession when in the right state

### DIFF
--- a/src/components/phone/Incoming.tsx
+++ b/src/components/phone/Incoming.tsx
@@ -36,14 +36,16 @@ class Incoming extends React.Component<Props> {
 
   handleAccept() {
     toneManager.stopAll()
-    this.props.session.accept({
-      sessionDescriptionHandlerOptions: {
-        constraints: {
-          audio: true,
-          video: false
+    if (this.props.session.state === SessionState.Initial) {
+      this.props.session.accept({
+        sessionDescriptionHandlerOptions: {
+          constraints: {
+            audio: true,
+            video: false
+          }
         }
-      }
-    })
+      })
+    }
     this.props.acceptCall(this.props.session)
   }
 
@@ -57,7 +59,12 @@ class Incoming extends React.Component<Props> {
 
   handleDecline() {
     toneManager.stopAll()
-    this.props.session.reject()
+    if (
+      this.props.session.state !== SessionState.Terminated &&
+      this.props.session.state !== SessionState.Terminating
+    ) {
+      this.props.session.reject()
+    }
     this.props.declineCall(this.props.session)
   }
 


### PR DESCRIPTION
Accepting a call that was terminated by the originator raise an error, and a similar error occur when declining a call that has been terminated.

This PR check the session state prior accepting or declining.