### PR TITLE
[fix](sessions) fix formatting in getFullNumber to work nicely with international number

### DIFF
--- a/src/util/sessions.ts
+++ b/src/util/sessions.ts
@@ -93,12 +93,19 @@ export const getFullNumber = (number: string) => {
   if (number.length < 10) {
     return number
   }
-  // @ts-ignore
-  let fullNumber = `+${phoneStore.getState().sipAccounts.sipAccount._config.defaultCountryCode}${number}`
-  if (number.includes('+') && number.length === 10) {
-    fullNumber = `${number}`
+  let fullNumber = `${number}`
+  // Remove leading + if already set
+  if (fullNumber.startsWith('+')) {
+    fullNumber = fullNumber.substring(1)
   }
-  console.log(fullNumber)
+  // Add default country code
+  // @ts-ignore
+  const countrycode = phoneStore.getState().sipAccounts.sipAccount._config.defaultCountryCode
+  fullNumber = `${countrycode}${number}`
+  if (!fullNumber.startsWith('+')) {
+    fullNumber = `+${number}`
+  }
+  console.log(`fullNumber: ${fullNumber}`)
   return fullNumber
 }
 

--- a/src/util/sessions.ts
+++ b/src/util/sessions.ts
@@ -89,6 +89,10 @@ export class SessionStateHandler {
   }
 }
 
+const sanitizePhoneNumber = (number: string) => {
+  return number.replace(/[^\d+]/g, '')
+}
+
 export const getFullNumber = (number: string) => {
   if (number.length < 10) {
     return number
@@ -101,8 +105,11 @@ export const getFullNumber = (number: string) => {
   // Add default country code
   // @ts-ignore
   const countrycode = phoneStore.getState().sipAccounts.sipAccount._config.defaultCountryCode
-  fullNumber = `+${countrycode}${fullNumber}`
+
+  // add + & sanitize phone number to remove parentheses, space & dash
+  fullNumber = sanitizePhoneNumber(`+${countrycode}${fullNumber}`)
   console.log(`fullNumber: ${fullNumber}`)
+
   return fullNumber
 }
 

--- a/src/util/sessions.ts
+++ b/src/util/sessions.ts
@@ -101,10 +101,7 @@ export const getFullNumber = (number: string) => {
   // Add default country code
   // @ts-ignore
   const countrycode = phoneStore.getState().sipAccounts.sipAccount._config.defaultCountryCode
-  fullNumber = `${countrycode}${number}`
-  if (!fullNumber.startsWith('+')) {
-    fullNumber = `+${number}`
-  }
+  fullNumber = `+${countrycode}${fullNumber}`
   console.log(`fullNumber: ${fullNumber}`)
   return fullNumber
 }

--- a/src/util/sessions.ts
+++ b/src/util/sessions.ts
@@ -98,6 +98,9 @@ export const getFullNumber = (number: string) => {
     return number
   }
   let fullNumber = `${number}`
+  // sanitize phone number to remove parentheses, space & dash
+  fullNumber = sanitizePhoneNumber(fullNumber)
+
   // Remove leading + if already set
   if (fullNumber.startsWith('+')) {
     fullNumber = fullNumber.substring(1)
@@ -106,8 +109,7 @@ export const getFullNumber = (number: string) => {
   // @ts-ignore
   const countrycode = phoneStore.getState().sipAccounts.sipAccount._config.defaultCountryCode
 
-  // add + & sanitize phone number to remove parentheses, space & dash
-  fullNumber = sanitizePhoneNumber(`+${countrycode}${fullNumber}`)
+  fullNumber = `+${countrycode}${fullNumber}`
   console.log(`fullNumber: ${fullNumber}`)
 
   return fullNumber


### PR DESCRIPTION
This PR attempts a better formatting of the outbound number to work with international calling.
For instance when calling `+34650740101` we ensure to not duplicate the `+` sign.


It might be worth in future version to integrate with https://www.npmjs.com/package/libphonenumber-js