### PR TITLE
[fix](sipaccount) allow to pass InviterOptions when making call

### DIFF
--- a/src/lib/SipAccount.ts
+++ b/src/lib/SipAccount.ts
@@ -11,6 +11,7 @@ import {
 } from 'sip.js'
 
 import { TransportOptions } from 'sip.js/lib/platform/web'
+import { InviterOptions } from "sip.js/lib/api"
 import { phoneStore } from '../index'
 import { NEW_USERAGENT } from '../actions/sipAccounts'
 import { SessionStateHandler, getFullNumber } from '../util/sessions'
@@ -118,7 +119,7 @@ export default class SIPAccount {
     })
   }
 
-  makeCall(number: string) {
+  makeCall(number: string, options: InviterOptions) {
     const state = phoneStore.getState()
     // @ts-ignore
     const sessionsLimit: number = state.config.phoneConfig.sessionsLimit
@@ -146,7 +147,7 @@ export default class SIPAccount {
 
       if (target) {
         console.log(`Calling ${number}`)
-        const inviter = new Inviter(this._userAgent, target)
+        const inviter = new Inviter(this._userAgent, target, options)
         // An Inviter is a Session
         const outgoingSession: Session = inviter
         // Setup outgoing session delegate


### PR DESCRIPTION
It would be very practical if we can allow to control the InviterOptions, for instance to set SIP Headers when making calls.

Usage:
```
      const InviterOptions = {
        extraHeaders: [
          'X-Referred-By-Someone: Username'
        ]
      }
      sipAccount.makeCall(phone_number, InviterOptions)
```